### PR TITLE
Use ThemeMode instead of ThemeData

### DIFF
--- a/lib/app.dart
+++ b/lib/app.dart
@@ -17,13 +17,14 @@ class App extends HookWidget {
     final setting =
         useProvider(appThemeNotifierProvider.select((value) => value.setting));
     final snapshot =
-        useFuture(useMemoized(() => appTheme.themeData, [setting]));
+        useFuture(useMemoized(() => appTheme.themeMode, [setting]));
 
     return snapshot.hasData
         ? GetMaterialApp(
             title: 'Flutter Architecture Blueprints',
-            theme: snapshot.data ?? lightTheme,
+            theme: lightTheme,
             darkTheme: darkTheme,
+            themeMode: snapshot.data ?? ThemeMode.light,
             home: HomePage(),
             localizationsDelegates: L10n.localizationsDelegates,
             supportedLocales: L10n.supportedLocales,

--- a/lib/data/local/theme_data_source.dart
+++ b/lib/data/local/theme_data_source.dart
@@ -1,7 +1,7 @@
-import '../model/theme_setting.dart';
+import 'package:flutter/material.dart';
 
 abstract class ThemeDataSource {
-  ThemeSetting loadThemeSetting();
+  ThemeMode loadThemeMode();
 
-  Future<void> saveThemeSetting(ThemeSetting theme);
+  Future<void> saveThemeMode(ThemeMode theme);
 }

--- a/lib/data/local/theme_data_source_impl.dart
+++ b/lib/data/local/theme_data_source_impl.dart
@@ -1,26 +1,24 @@
 import 'package:enum_to_string/enum_to_string.dart';
-import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
-import '../model/theme_setting.dart';
 import 'theme_data_source.dart';
 
 class ThemeDataSourceImpl extends ThemeDataSource {
   ThemeDataSourceImpl({@required SharedPreferences prefs}) : _prefs = prefs;
 
-  static const String keyThemeSetting = 'theme_setting';
+  static const String keyThemeMode = 'theme_mode';
 
   final SharedPreferences _prefs;
 
   @override
-  ThemeSetting loadThemeSetting() {
+  ThemeMode loadThemeMode() {
     return EnumToString.fromString(
-        ThemeSetting.values, _prefs.getString(keyThemeSetting));
+        ThemeMode.values, _prefs.getString(keyThemeMode));
   }
 
   @override
-  Future<void> saveThemeSetting(ThemeSetting theme) {
-    return _prefs.setString(
-        keyThemeSetting, EnumToString.convertToString(theme));
+  Future<void> saveThemeMode(ThemeMode theme) {
+    return _prefs.setString(keyThemeMode, EnumToString.convertToString(theme));
   }
 }

--- a/lib/data/model/theme_setting.dart
+++ b/lib/data/model/theme_setting.dart
@@ -1,1 +1,0 @@
-enum ThemeSetting { light, dark }

--- a/lib/data/repository/theme_repository.dart
+++ b/lib/data/repository/theme_repository.dart
@@ -1,7 +1,7 @@
-import '../model/theme_setting.dart';
+import 'package:flutter/material.dart';
 
 abstract class ThemeRepository {
-  ThemeSetting loadThemeSetting();
+  ThemeMode loadThemeMode();
 
-  Future<void> saveThemeSetting(ThemeSetting theme);
+  Future<void> saveThemeMode(ThemeMode theme);
 }

--- a/lib/data/repository/theme_repository_impl.dart
+++ b/lib/data/repository/theme_repository_impl.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/material.dart';
 
 import '../local/theme_data_source.dart';
-import '../model/theme_setting.dart';
 import 'theme_repository.dart';
 
 class ThemeRepositoryImpl implements ThemeRepository {
@@ -11,12 +10,12 @@ class ThemeRepositoryImpl implements ThemeRepository {
   final ThemeDataSource _dataSource;
 
   @override
-  ThemeSetting loadThemeSetting() {
-    return _dataSource.loadThemeSetting();
+  ThemeMode loadThemeMode() {
+    return _dataSource.loadThemeMode();
   }
 
   @override
-  Future<void> saveThemeSetting(ThemeSetting theme) {
-    return _dataSource.saveThemeSetting(theme);
+  Future<void> saveThemeMode(ThemeMode theme) {
+    return _dataSource.saveThemeMode(theme);
   }
 }

--- a/lib/ui/app_theme.dart
+++ b/lib/ui/app_theme.dart
@@ -2,7 +2,6 @@ import 'package:flutter/material.dart';
 import 'package:google_fonts/google_fonts.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 
-import '../data/model/theme_setting.dart';
 import '../data/provider/theme_repository_provider.dart';
 import '../data/repository/theme_repository.dart';
 import 'change_notifier_with_error_handle.dart';
@@ -61,39 +60,37 @@ class AppTheme extends AppChangeNotifier {
       : _ref = ref,
         super(ref);
 
-  static const _defaultThemeSetting = ThemeSetting.light;
+  static const _defaultThemeMode = ThemeMode.light;
 
   final ProviderReference _ref;
 
   ThemeRepository _repository;
 
-  ThemeSetting _setting;
+  ThemeMode _setting;
 
-  ThemeSetting get setting => _setting;
+  ThemeMode get setting => _setting;
 
-  Future<ThemeData> get themeData async {
+  Future<ThemeMode> get themeMode async {
     if (setting == null) {
       _repository ??= await _ref.read(themeRepositoryProvider.future);
-      _setting = _repository.loadThemeSetting() ?? _defaultThemeSetting;
+      _setting = _repository.loadThemeMode() ?? _defaultThemeMode;
     }
-    return setting == ThemeSetting.light ? lightTheme : darkTheme;
+    return setting;
   }
 
-  Future<void> _loadLightTheme() async {
+  Future<void> _loadLightMode() async {
     _repository ??= await _ref.read(themeRepositoryProvider.future);
-    _setting = ThemeSetting.light;
-    await _repository.saveThemeSetting(setting).whenComplete(notifyListeners);
+    _setting = ThemeMode.light;
+    await _repository.saveThemeMode(setting).whenComplete(notifyListeners);
   }
 
-  Future<void> _loadDarkTheme() async {
+  Future<void> _loadDarkMode() async {
     _repository ??= await _ref.read(themeRepositoryProvider.future);
-    _setting = ThemeSetting.dark;
-    await _repository.saveThemeSetting(setting).whenComplete(notifyListeners);
+    _setting = ThemeMode.dark;
+    await _repository.saveThemeMode(setting).whenComplete(notifyListeners);
   }
 
   Future<void> toggle() async {
-    setting == ThemeSetting.light
-        ? await _loadDarkTheme()
-        : await _loadLightTheme();
+    setting == ThemeMode.light ? await _loadDarkMode() : await _loadLightMode();
   }
 }

--- a/test/data/local/fake_theme_data_source_impl.dart
+++ b/test/data/local/fake_theme_data_source_impl.dart
@@ -1,14 +1,14 @@
 import 'package:app/data/local/theme_data_source.dart';
-import 'package:app/data/model/theme_setting.dart';
+import 'package:flutter/material.dart';
 
 class FakeThemeDataSourceImpl extends ThemeDataSource {
   @override
-  ThemeSetting loadThemeSetting() {
-    return ThemeSetting.dark;
+  ThemeMode loadThemeMode() {
+    return ThemeMode.dark;
   }
 
   @override
-  Future<void> saveThemeSetting(ThemeSetting theme) async {
+  Future<void> saveThemeMode(ThemeMode theme) async {
     // no-op
   }
 }

--- a/test/ui/app_theme_test.dart
+++ b/test/ui/app_theme_test.dart
@@ -1,5 +1,5 @@
-import 'package:app/data/model/theme_setting.dart';
 import 'package:app/ui/app_theme.dart';
+import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:mockito/mockito.dart';
@@ -10,7 +10,7 @@ class MockAppTheme extends Mock implements AppTheme {}
 void main() {
   setUp(() async {
     SharedPreferences.setMockInitialValues(
-        <String, String>{'theme_setting': 'dark'});
+        <String, String>{'theme_mode': 'dark'});
   });
 
   test('AppTheme + ThemeRepository Test', () async {
@@ -22,12 +22,12 @@ void main() {
       ],
     );
     final appTheme = container.read(appThemeNotifierProvider);
-    await expectLater(appTheme.themeData, completion(darkTheme));
-    expect(appTheme.setting, ThemeSetting.dark);
+    await expectLater(appTheme.themeMode, completion(ThemeMode.dark));
+    expect(appTheme.setting, ThemeMode.dark);
 
     await appTheme.toggle();
 
-    await expectLater(appTheme.themeData, completion(lightTheme));
-    expect(appTheme.setting, ThemeSetting.light);
+    await expectLater(appTheme.themeMode, completion(ThemeMode.light));
+    expect(appTheme.setting, ThemeMode.light);
   });
 }

--- a/test/ui/widget_test.dart
+++ b/test/ui/widget_test.dart
@@ -1,7 +1,6 @@
 import 'package:app/app.dart';
 import 'package:app/constants.dart';
 import 'package:app/data/app_error.dart';
-import 'package:app/data/model/theme_setting.dart';
 import 'package:app/ui/app_theme.dart';
 import 'package:app/ui/component/article_item.dart';
 import 'package:app/ui/component/loading.dart';
@@ -35,14 +34,14 @@ void main() {
   when(mockErrorNotifier.getErrorIfNotHandled()).thenReturn(ApiError(Error()));
 
   final mockAppTheme = MockAppTheme();
-  when(mockAppTheme.setting).thenReturn(ThemeSetting.light);
-  when(mockAppTheme.themeData).thenAnswer((_) => Future.value(lightTheme));
+  when(mockAppTheme.setting).thenReturn(ThemeMode.light);
+  when(mockAppTheme.themeMode).thenAnswer((_) => Future.value(ThemeMode.light));
 
   final mockHomeViewModel = MockHomeViewModel();
   when(mockHomeViewModel.fetchNews()).thenAnswer((_) => Future.value());
   when(mockHomeViewModel.news).thenReturn(dummyNews);
   when(mockHomeViewModel.hasArticle).thenReturn(true);
-  when(mockAppTheme.themeData).thenAnswer((_) => Future.value(lightTheme));
+  when(mockAppTheme.themeMode).thenAnswer((_) => Future.value(ThemeMode.light));
 
   final mockNavigatorObserver = MockNavigatorObserver();
 


### PR DESCRIPTION
### What does this change?

Use the `themeMode` property instead of the` ThemeData` class.
ref <https://api.flutter.dev/flutter/material/MaterialApp/themeMode.html>

### What is the value of this and can you measure success?

- will be able to select dark mode, light mode, and system preference

### Screenshots (Optional)

- none


