### PR TITLE
fix: DON'T CALL READ INSIDE THE BODY OF A PROVIDER

### DIFF
--- a/lib/data/provider/auth_data_source_provider.dart
+++ b/lib/data/provider/auth_data_source_provider.dart
@@ -2,7 +2,6 @@ import 'package:hooks_riverpod/hooks_riverpod.dart';
 
 import '../remote/auth_data_source.dart';
 import '../remote/auth_data_source_impl.dart';
-import 'firebase_auth_provider.dart';
 
-final authDataSourceProvider = Provider<AuthDataSource>(
-    (ref) => AuthDataSourceImpl(ref.read(firebaseAuthProvider)));
+final authDataSourceProvider =
+    Provider<AuthDataSource>((ref) => AuthDataSourceImpl(ref.read));

--- a/lib/data/provider/news_data_source_provider.dart
+++ b/lib/data/provider/news_data_source_provider.dart
@@ -2,7 +2,6 @@ import 'package:hooks_riverpod/hooks_riverpod.dart';
 
 import '../remote/news_data_source.dart';
 import '../remote/news_data_source_impl.dart';
-import 'dio_provider.dart';
 
-final newsDataSourceProvider = Provider<NewsDataSource>(
-    (ref) => NewsDataSourceImpl(dio: ref.read(dioProvider)));
+final newsDataSourceProvider =
+    Provider<NewsDataSource>((ref) => NewsDataSourceImpl(ref.read));

--- a/lib/data/remote/auth_data_source_impl.dart
+++ b/lib/data/remote/auth_data_source_impl.dart
@@ -1,13 +1,16 @@
 import 'package:firebase_auth/firebase_auth.dart' as firebase;
 import 'package:flutter/foundation.dart';
 import 'package:google_sign_in/google_sign_in.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
 
+import '../provider/firebase_auth_provider.dart';
 import 'auth_data_source.dart';
 
 class AuthDataSourceImpl implements AuthDataSource {
-  AuthDataSourceImpl(this._firebaseAuth);
+  final Reader _read;
+  AuthDataSourceImpl(this._read);
 
-  final firebase.FirebaseAuth _firebaseAuth;
+  firebase.FirebaseAuth get _firebaseAuth => _read(firebaseAuthProvider);
 
   @override
   Future<firebase.User?> signIn() async {

--- a/lib/data/remote/news_data_source_impl.dart
+++ b/lib/data/remote/news_data_source_impl.dart
@@ -1,16 +1,19 @@
 import 'dart:math';
 
 import 'package:dio/dio.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
 
 import '../../constants.dart';
 import '../../util/ext/date_time.dart';
 import '../model/news.dart';
+import '../provider/dio_provider.dart';
 import 'news_data_source.dart';
 
 class NewsDataSourceImpl implements NewsDataSource {
-  NewsDataSourceImpl({required Dio dio}) : _dio = dio;
+  final Reader _read;
+  NewsDataSourceImpl(this._read);
 
-  final Dio _dio;
+  Dio get _dio => _read(dioProvider);
 
   @override
   Future<News> getNews() {

--- a/lib/ui/home/home_view_model.dart
+++ b/lib/ui/home/home_view_model.dart
@@ -6,13 +6,14 @@ import '../../data/model/result.dart';
 import '../../data/provider/news_repository_provider.dart';
 import '../../data/repository/news_repository.dart';
 
-final homeViewModelProvider = ChangeNotifierProvider(
-    (ref) => HomeViewModel(ref.read(newsRepositoryProvider)));
+final homeViewModelProvider =
+    ChangeNotifierProvider((ref) => HomeViewModel(ref.read));
 
 class HomeViewModel extends ChangeNotifier {
-  HomeViewModel(this._repository);
+  final Reader _read;
+  HomeViewModel(this._read);
 
-  final NewsRepository _repository;
+  NewsRepository get _repository => _read(newsRepositoryProvider);
 
   // Result use case No.1
   Result<News>? _news;

--- a/lib/ui/user_view_model.dart
+++ b/lib/ui/user_view_model.dart
@@ -5,13 +5,14 @@ import 'package:hooks_riverpod/hooks_riverpod.dart';
 import '../data/provider/auth_repository_provider.dart';
 import '../data/repository/auth_repository.dart';
 
-final userViewModelProvider = ChangeNotifierProvider(
-    (ref) => UserViewModel(ref.read(authRepositoryProvider)));
+final userViewModelProvider =
+    ChangeNotifierProvider((ref) => UserViewModel(ref.read));
 
 class UserViewModel extends ChangeNotifier {
-  UserViewModel(this._repository);
+  final Reader _read;
+  UserViewModel(this._read);
 
-  final AuthRepository _repository;
+  AuthRepository get _repository => _read(authRepositoryProvider);
 
   firebase.User? _user;
 


### PR DESCRIPTION
### What does this change?
`riverpod` 公式のドキュメントの以下の項によると
https://riverpod.dev/docs/concepts/combining_providers#can-i-read-a-provider-without-listening-to-it

```
final myProvider = Provider((ref) {
  // Bad practice to call `read` here
  final value = ref.read(anotherProvider);
});
```
`Provider` 内で 別 `Provider` を読み込むのは `Bad practice` とのことなので修正しました。

