### PR TITLE
[fix] delete "abstract" of freezed model

### DIFF
--- a/lib/data/model/article.dart
+++ b/lib/data/model/article.dart
@@ -5,7 +5,7 @@ part 'article.freezed.dart';
 part 'article.g.dart';
 
 @freezed
-abstract class Article with _$Article {
+class Article with _$Article {
   factory Article({
     Source? source,
     String? author,

--- a/lib/data/model/news.dart
+++ b/lib/data/model/news.dart
@@ -5,7 +5,7 @@ part 'news.freezed.dart';
 part 'news.g.dart';
 
 @freezed
-abstract class News with _$News {
+class News with _$News {
   factory News({
     required String status,
     required int totalResults,

--- a/lib/data/model/result.dart
+++ b/lib/data/model/result.dart
@@ -5,7 +5,7 @@ import 'package:freezed_annotation/freezed_annotation.dart';
 part 'result.freezed.dart';
 
 @freezed
-abstract class Result<T> with _$Result<T> {
+class Result<T> with _$Result<T> {
   const Result._();
 
   const factory Result.success({required T data}) = Success<T>;

--- a/lib/data/model/source.dart
+++ b/lib/data/model/source.dart
@@ -5,7 +5,7 @@ part 'source.freezed.dart';
 part 'source.g.dart';
 
 @freezed
-abstract class Source with _$Source {
+class Source with _$Source {
   factory Source({
     String? id,
     String? name,


### PR DESCRIPTION
### What does this change?

https://github.com/rrousselGit/freezed

> The abstract keyword
As you might have noticed, the abstract keyword is not needed anymore when declaring freezed classes.
