### PR TITLE
fix contributing link

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Flutter Architecture Blueprints is a project that introduces MVVM architecture a
 
 - [Install Flutter](https://flutter.dev/get-started/)
 - [Flutter documentation](https://flutter.dev/docs)
-- [Contributing to Flutter](https://github.com/wasabeef/flutter-architecture-blueprints/blob/main/CONTRIBUTING.md)
+- [Contributing to Flutter](https://github.com/wasabeef/flutter-architecture-blueprints/blob/main/CODE_OF_CONDUCT.md)
 
 ## Installation
 


### PR DESCRIPTION
### What does this change?

link returns 404 page. fix page link.

https://github.com/wasabeef/flutter-architecture-blueprints/commit/eec4d7ff38f34693c6833cf53f6ecb584f55944d

### Screenshots (Optional)


